### PR TITLE
Add specific readme requirements to review template

### DIFF
--- a/content/appendices/templates.md
+++ b/content/appendices/templates.md
@@ -44,6 +44,23 @@ The package includes all the following forms of documentation:
 - [ ] **Examples** for all user-facing functions
 - [ ] **Community guidelines** including contribution guidelines in the README or CONTRIBUTING, and DESCRIPTION with `URL`, `BugReports` and `Maintainer`.
 
+Readme requirements
+The package meets the readme requirements below:
+
+- [ ] Package has a README.md file in the root directory. 
+
+The README should include, from top to bottom:
+
+- [ ] The package name
+- [ ] Badges for continuous integration and test coverage, the badge for pyOpenSci peer-review once it has started (see below), a repostatus.org badge, and any other badges. If the README has many more badges, you might want to consider using a table for badges, see this example, that one and that one. Such a table should be more wide than high.
+- [ ] Short description of goals of package, with descriptive links to all vignettes (rendered, i.e. readable, cf the documentation website section) unless the package is small and there’s only one vignette repeating the README.
+- [ ] Installation instructions
+- [ ] Any additional setup required (authentication tokens, etc)
+- [ ] Brief demonstration usage
+- [ ] Direction to more detailed documentation (e.g. your documentation files or website).
+- [ ] If applicable, how the package compares to other similar packages and/or how it relates to other packages
+- [ ] Citation information
+
 #### Functionality
 
 - [ ] **Installation:** Installation succeeds as documented.


### PR DESCRIPTION
This is a suggestion to avoid confusion in what belongs in the readme of all packages. 