### PR TITLE
Remove reference to DESCRIPTION

### DIFF
--- a/content/appendices/templates.md
+++ b/content/appendices/templates.md
@@ -42,12 +42,13 @@ The package includes all the following forms of documentation:
 - [ ] **Vignette(s)** demonstrating major functionality that runs successfully locally
 - [ ] **Function Documentation:** for all user-facing functions
 - [ ] **Examples** for all user-facing functions
-- [ ] **Community guidelines** including contribution guidelines in the README or CONTRIBUTING, and DESCRIPTION with `URL`, `BugReports` and `Maintainer`.
+- [ ] **Community guidelines** including contribution guidelines in the README or CONTRIBUTING.
+- [ ] **Metadata** including author(s), author e-mail(s), and a url, e.g., in a `setup.py` file or elsewhere.
 
 Readme requirements
 The package meets the readme requirements below:
 
-- [ ] Package has a README.md file in the root directory. 
+- [ ] Package has a README.md file in the root directory.
 
 The README should include, from top to bottom:
 

--- a/content/appendices/templates.md
+++ b/content/appendices/templates.md
@@ -43,7 +43,7 @@ The package includes all the following forms of documentation:
 - [ ] **Function Documentation:** for all user-facing functions
 - [ ] **Examples** for all user-facing functions
 - [ ] **Community guidelines** including contribution guidelines in the README or CONTRIBUTING.
-- [ ] **Metadata** including author(s), author e-mail(s), and a url, e.g., in a `setup.py` file or elsewhere.
+- [ ] **Metadata** including author(s), author e-mail(s), a url, and any other relevant metadata e.g., in a `setup.py` file or elsewhere.
 
 Readme requirements
 The package meets the readme requirements below:


### PR DESCRIPTION
This is a stab at fixing #33, which references a `DESCRIPTION` file (an R thing). Instead, the metadata on urls, authors, etc. might go in a `setup.py` file. I kept the language somewhat vague to accommodate exceptional circumstances, but I think we should at least ask for the URL and author info somewhere. 